### PR TITLE
Update EncryptorClass.php

### DIFF
--- a/EncryptorClass.php
+++ b/EncryptorClass.php
@@ -26,7 +26,7 @@ class Encryptor{
     }
     function saltor($rnds,$type) {
         
-        $rand_num = base64_encode(mcrypt_create_iv(22,MCRYPT_DEV_URANDOM));
+        $rand_num = base64_encode(random_bytes(22));
         
         if($type == "SHA256") {
             


### PR DESCRIPTION
As mcrypt_create_iv was deprecated in PHP 7.1.0 and was removed in PHP 7.2.0, I have used random_bytes as the alternative given at https://www.php.net/manual/en/function.mcrypt-create-iv.php.